### PR TITLE
Use API key when running Safety

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4
         with:
           # Version range or exact version of a Python version to use, using SemVer's version range syntax.
-          python-version: 3.6
+          python-version: '3.10'
           
       - name: Install Ahjo
         run: pip install .
@@ -30,5 +30,5 @@ jobs:
         run: pip install safety
 
       - name: Run vulnerability scan
-        run: safety check
+        run: safety check --key ${{secrets.PYUP_API_KEY}}
 


### PR DESCRIPTION
- Make Safety use the API key
- Update actions/checkout
- Update actions/setup-python and Python version

DP-270

Check the Actions tab to see the pipeline logs.